### PR TITLE
✨ [FEAT]: 알림 조회 API 개발

### DIFF
--- a/src/main/java/depth/jeonsilog/JeonsiLogServerApplication.java
+++ b/src/main/java/depth/jeonsilog/JeonsiLogServerApplication.java
@@ -2,7 +2,9 @@ package depth.jeonsilog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class JeonsiLogServerApplication {
 

--- a/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
@@ -1,26 +1,118 @@
 package depth.jeonsilog.domain.alarm.application;
 
+import depth.jeonsilog.domain.alarm.converter.AlarmConverter;
 import depth.jeonsilog.domain.alarm.domain.Alarm;
 import depth.jeonsilog.domain.alarm.domain.AlarmType;
 import depth.jeonsilog.domain.alarm.domain.repository.AlarmRepository;
+import depth.jeonsilog.domain.alarm.dto.AlarmResponseDto;
+import depth.jeonsilog.domain.exhibition.domain.Exhibition;
+import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
+import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
 import depth.jeonsilog.domain.follow.domain.Follow;
 import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
+import depth.jeonsilog.domain.interest.domain.Interest;
+import depth.jeonsilog.domain.interest.domain.repository.InterestRepository;
 import depth.jeonsilog.domain.rating.domain.Rating;
 import depth.jeonsilog.domain.reply.domain.Reply;
 import depth.jeonsilog.domain.review.domain.Review;
+import depth.jeonsilog.domain.user.application.UserService;
+import depth.jeonsilog.domain.user.domain.User;
+import depth.jeonsilog.domain.user.domain.repository.UserRepository;
+import depth.jeonsilog.global.DefaultAssert;
+import depth.jeonsilog.global.config.security.token.UserPrincipal;
+import depth.jeonsilog.global.payload.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class AlarmService {
 
     private final AlarmRepository alarmRepository;
     private final FollowRepository followRepository;
+    private final InterestRepository interestRepository;
+    private final UserRepository userRepository;
+    private final ExhibitionRepository exhibitionRepository;
+    private final UserService userService;
+
+    private static String BEFORE_7DAYS = "전시 시작까지 7일 남았어요";
+    private static String BEFORE_3DAYS = "전시 시작까지 3일 남았어요";
+    private static String BEFORE_1DAYS = "전시 시작까지 1일 남았어요";
+
+    // TODO: 활동 알림 목록 조회
+    public ResponseEntity<?> getActivityAlarmList(UserPrincipal userPrincipal) {
+        User findUser = userService.validateUserByToken(userPrincipal);
+        List<AlarmType> types = Arrays.asList(AlarmType.RATING, AlarmType.REVIEW, AlarmType.REPLY, AlarmType.FOLLOW);
+        List<Alarm> alarms = alarmRepository.findByUserIdAndAlarmTypeIn(findUser.getId(), types);
+
+        List<AlarmResponseDto.AlarmRes> alarmResList = new ArrayList<>();
+        for (Alarm alarm : alarms) {
+            Optional<User> sender = userRepository.findById(alarm.getSenderId());
+            DefaultAssert.isTrue(sender.isPresent());
+
+            String content = "";
+            switch (alarm.getAlarmType()) {
+                case REVIEW -> content = sender.get().getNickname() + " 님이 감상평을 남겼어요";
+                case RATING -> content = sender.get().getNickname() + " 님이 별점을 남겼어요";
+                case REPLY -> content = sender.get().getNickname() + " 님이 내 감상평에 댓글을 남겼어요";
+                case FOLLOW -> content = sender.get().getNickname() + " 님이 나를 팔로우해요";
+            }
+
+            AlarmResponseDto.AlarmRes alarmRes = AlarmResponseDto.AlarmRes.builder()
+                    .alarmId(alarm.getId())
+                    .alarmType(alarm.getAlarmType())
+                    .targetId(alarm.getTargetId())
+                    .clickId(alarm.getClickId())
+                    .imgUrl(sender.get().getProfileImg())
+                    .contents(content)
+                    .dateTime(alarm.getCreatedDate())
+                    .build();
+            alarmResList.add(alarmRes);
+        }
+
+        ApiResponse apiResponse = ApiResponse.toApiResponse(alarmResList);
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    // TODO: 전시 알림 목록 조회
+    public ResponseEntity<?> getExhibitionAlarmList(UserPrincipal userPrincipal) {
+        User findUser = userService.validateUserByToken(userPrincipal);
+        List<AlarmType> types = List.of(AlarmType.EXHIBITION);
+        List<Alarm> alarms = alarmRepository.findByUserIdAndAlarmTypeIn(findUser.getId(), types);
+
+        List<AlarmResponseDto.AlarmRes> alarmResList = new ArrayList<>();
+        for (Alarm alarm : alarms) {
+            Optional<Exhibition> exhibition = exhibitionRepository.findById(alarm.getTargetId());
+            DefaultAssert.isTrue(exhibition.isPresent());
+            AlarmResponseDto.AlarmRes alarmRes = AlarmResponseDto.AlarmRes.builder()
+                    .alarmId(alarm.getId())
+                    .alarmType(alarm.getAlarmType())
+                    .targetId(alarm.getTargetId())
+                    .clickId(alarm.getClickId())
+                    .imgUrl(exhibition.get().getImageUrl())
+                    .contents("[" + exhibition.get().getName() + "] " + alarm.getContents())
+                    .dateTime(alarm.getCreatedDate())
+                    .build();
+            alarmResList.add(alarmRes);
+        }
+
+        ApiResponse apiResponse = ApiResponse.toApiResponse(alarmResList);
+        return ResponseEntity.ok(apiResponse);
+    }
 
     // TODO: 팔로잉한 사람의 new 감상평 -> 알림 생성
     @Transactional
@@ -29,8 +121,10 @@ public class AlarmService {
         for (Follow follow : follows) {
             Alarm alarm = Alarm.builder()
                     .user(follow.getUser())
+                    .senderId(follow.getFollow().getId())
                     .alarmType(AlarmType.REVIEW)
                     .targetId(review.getId())
+                    .clickId(review.getId())
                     .build();
             alarmRepository.save(alarm);
         }
@@ -43,8 +137,10 @@ public class AlarmService {
         for (Follow follow : follows) {
             Alarm alarm = Alarm.builder()
                     .user(follow.getUser())
+                    .senderId(follow.getFollow().getId())
                     .alarmType(AlarmType.RATING)
                     .targetId(rating.getId())
+                    .clickId(rating.getExhibition().getId())
                     .build();
             alarmRepository.save(alarm);
         }
@@ -55,8 +151,10 @@ public class AlarmService {
     public void makeReplyAlarm(Reply reply) {
         Alarm alarm = Alarm.builder()
                 .user(reply.getReview().getUser())
+                .senderId(reply.getUser().getId())
                 .alarmType(AlarmType.REPLY)
                 .targetId(reply.getId())
+                .clickId(reply.getReview().getId())
                 .build();
         alarmRepository.save(alarm);
     }
@@ -66,9 +164,46 @@ public class AlarmService {
     public void makeFollowAlarm(Follow follow) {
         Alarm alarm = Alarm.builder()
                 .user(follow.getFollow())
+                .senderId(follow.getUser().getId())
                 .alarmType(AlarmType.FOLLOW)
                 .targetId(follow.getId())
+                .clickId(follow.getUser().getId())
                 .build();
         alarmRepository.save(alarm);
+    }
+
+    // 관심 전시회 시작 전 -> 알림 생성
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정에 실행
+    public void makeExhibitionAlarm() {
+        List<Interest> interests = interestRepository.findByExhibition_OperatingKeyword(OperatingKeyword.BEFORE_DISPLAY);
+
+        LocalDate currentDate = LocalDate.now();
+        log.info("현재 날짜: " + currentDate);
+        for (Interest interest : interests) {
+            Exhibition exhibition = interest.getExhibition();
+
+            LocalDate targetDate = LocalDate.parse(exhibition.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+            log.info("전시회 시작 날짜: " + targetDate);
+
+            Alarm alarm = null;
+            long daysDifference = ChronoUnit.DAYS.between(currentDate, targetDate);
+            if (daysDifference == 7) {
+                if (checkDuplicateAlarm(interest.getUser().getId(), interest.getExhibition().getId(), BEFORE_7DAYS)) continue;
+                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_7DAYS);
+            } else if (daysDifference == 3) {
+                if (checkDuplicateAlarm(interest.getUser().getId(), interest.getExhibition().getId(), BEFORE_3DAYS)) continue;
+                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_3DAYS);
+            } else if (daysDifference == 1) {
+                if (checkDuplicateAlarm(interest.getUser().getId(), interest.getExhibition().getId(), BEFORE_1DAYS)) continue;
+                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_1DAYS);
+            }
+            assert alarm != null;
+            alarmRepository.save(alarm);
+        }
+    }
+
+    public boolean checkDuplicateAlarm(Long userId, Long targetId, String contents) {
+        return alarmRepository.existsByUserIdAndTargetIdAndContents(userId, targetId, contents);
     }
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
@@ -1,0 +1,74 @@
+package depth.jeonsilog.domain.alarm.application;
+
+import depth.jeonsilog.domain.alarm.domain.Alarm;
+import depth.jeonsilog.domain.alarm.domain.AlarmType;
+import depth.jeonsilog.domain.alarm.domain.repository.AlarmRepository;
+import depth.jeonsilog.domain.follow.domain.Follow;
+import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
+import depth.jeonsilog.domain.rating.domain.Rating;
+import depth.jeonsilog.domain.reply.domain.Reply;
+import depth.jeonsilog.domain.review.domain.Review;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AlarmService {
+
+    private final AlarmRepository alarmRepository;
+    private final FollowRepository followRepository;
+
+    // TODO: 팔로잉한 사람의 new 감상평 -> 알림 생성
+    @Transactional
+    public void makeReviewAlarm(Review review) {
+        List<Follow> follows = followRepository.findAllByFollow(review.getUser());
+        for (Follow follow : follows) {
+            Alarm alarm = Alarm.builder()
+                    .user(follow.getUser())
+                    .alarmType(AlarmType.REVIEW)
+                    .targetId(review.getId())
+                    .build();
+            alarmRepository.save(alarm);
+        }
+    }
+
+    // 팔로잉한 사람의 new 별점 -> 알림 생성
+    @Transactional
+    public void makeRatingAlarm(Rating rating) {
+        List<Follow> follows = followRepository.findAllByFollow(rating.getUser());
+        for (Follow follow : follows) {
+            Alarm alarm = Alarm.builder()
+                    .user(follow.getUser())
+                    .alarmType(AlarmType.RATING)
+                    .targetId(rating.getId())
+                    .build();
+            alarmRepository.save(alarm);
+        }
+    }
+
+    // 나의 감상평에 달린 댓글 -> 알림 생성
+    @Transactional
+    public void makeReplyAlarm(Reply reply) {
+        Alarm alarm = Alarm.builder()
+                .user(reply.getReview().getUser())
+                .alarmType(AlarmType.REPLY)
+                .targetId(reply.getId())
+                .build();
+        alarmRepository.save(alarm);
+    }
+
+    // 나를 팔로우 -> 알림 생성
+    @Transactional
+    public void makeFollowAlarm(Follow follow) {
+        Alarm alarm = Alarm.builder()
+                .user(follow.getFollow())
+                .alarmType(AlarmType.FOLLOW)
+                .targetId(follow.getId())
+                .build();
+        alarmRepository.save(alarm);
+    }
+}

--- a/src/main/java/depth/jeonsilog/domain/alarm/converter/AlarmConverter.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/converter/AlarmConverter.java
@@ -1,0 +1,5 @@
+package depth.jeonsilog.domain.alarm.converter;
+
+public class AlarmConverter {
+
+}

--- a/src/main/java/depth/jeonsilog/domain/alarm/converter/AlarmConverter.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/converter/AlarmConverter.java
@@ -1,5 +1,18 @@
 package depth.jeonsilog.domain.alarm.converter;
 
+import depth.jeonsilog.domain.alarm.domain.Alarm;
+import depth.jeonsilog.domain.alarm.domain.AlarmType;
+import depth.jeonsilog.domain.interest.domain.Interest;
+
 public class AlarmConverter {
 
+    public static Alarm toExhibitionAlarm(Interest interest, String contents) {
+        return Alarm.builder()
+                .user(interest.getUser())
+                .alarmType(AlarmType.EXHIBITION)
+                .targetId(interest.getExhibition().getId())
+                .clickId(interest.getExhibition().getId())
+                .contents(contents)
+                .build();
+    }
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/domain/Alarm.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/domain/Alarm.java
@@ -24,13 +24,13 @@ public class Alarm extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AlarmType alarmType;
 
-    private String contents;
+    private Long targetId;
 
     @Builder
-    public Alarm(Long id, User user, AlarmType alarmType, String contents) {
+    public Alarm(Long id, User user, AlarmType alarmType, Long targetId) {
         this.id = id;
         this.user = user;
         this.alarmType = alarmType;
-        this.contents = contents;
+        this.targetId = targetId;
     }
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/domain/Alarm.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/domain/Alarm.java
@@ -2,6 +2,7 @@ package depth.jeonsilog.domain.alarm.domain;
 
 import depth.jeonsilog.domain.common.BaseEntity;
 import depth.jeonsilog.domain.user.domain.User;
+import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,16 +22,29 @@ public class Alarm extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
+    // 알림 생성자(송신자)의 유저 id를 저장한다. 전시회 알림에는 필요하지 않기 때문에 Nullable로 설정한다. 추후 리팩토링 가능성 있음
+    @Nullable
+    private Long senderId;
+
     @Enumerated(EnumType.STRING)
     private AlarmType alarmType;
 
     private Long targetId;
 
+    private Long clickId;
+
+    // 전시회 알림의 내용만 저장한다. (7,3,1일) 나머지 알림은 유저 닉네임의 변경 가능성 때문에 저장하지 않음
+    @Nullable
+    private String contents;
+
     @Builder
-    public Alarm(Long id, User user, AlarmType alarmType, Long targetId) {
+    public Alarm(Long id, User user, @Nullable Long senderId, AlarmType alarmType, Long targetId, Long clickId, @Nullable String contents) {
         this.id = id;
         this.user = user;
+        this.senderId = senderId;
         this.alarmType = alarmType;
         this.targetId = targetId;
+        this.clickId = clickId;
+        this.contents = contents;
     }
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/domain/AlarmType.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/domain/AlarmType.java
@@ -1,5 +1,5 @@
 package depth.jeonsilog.domain.alarm.domain;
 
 public enum AlarmType {
-    FOLLOWING, MY_ACTIVITY
+    RATING, REVIEW, REPLY, FOLLOW, EXHIBITION
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/domain/repository/AlarmRepository.java
@@ -1,0 +1,10 @@
+package depth.jeonsilog.domain.alarm.domain.repository;
+
+import depth.jeonsilog.domain.alarm.domain.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+}

--- a/src/main/java/depth/jeonsilog/domain/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/domain/repository/AlarmRepository.java
@@ -1,10 +1,16 @@
 package depth.jeonsilog.domain.alarm.domain.repository;
 
 import depth.jeonsilog.domain.alarm.domain.Alarm;
+import depth.jeonsilog.domain.alarm.domain.AlarmType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
+    List<Alarm> findByUserIdAndAlarmTypeIn(Long userId, List<AlarmType> types);
+
+    Boolean existsByUserIdAndTargetIdAndContents(Long userId, Long targetId, String contents);
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/dto/AlarmResponseDto.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/dto/AlarmResponseDto.java
@@ -1,0 +1,37 @@
+package depth.jeonsilog.domain.alarm.dto;
+
+import depth.jeonsilog.domain.alarm.domain.AlarmType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+public class AlarmResponseDto {
+
+    @Data
+    @Builder
+    public static class AlarmRes {
+
+        @Schema(type = "long", example = "1", description = "알림 ID를 출력합니다.")
+        private Long alarmId;
+
+        @Schema(type = "enum", example = "REVIEW", description = "알림 타입을 출력합니다.")
+        private AlarmType alarmType;
+
+        @Schema(type = "long", example = "1", description = "각 알림 타입에 따라 감상평ID, 댓글ID 등을 targetId 로 설정한다.")
+        private Long targetId;
+
+        @Schema(type = "long", example = "1", description = "클릭 시 페이지 이동에 필요한 ID를 clickId 로 설정한다.")
+        private Long clickId;
+
+        @Schema(type = "string", example = "https://..", description = "이미지 url을 출력한다.")
+        private String imgUrl;
+
+        @Schema(type = "string", example = "루피 님이 나를 팔로우해요", description = "알림 내용을 출력합니다.")
+        private String contents;
+
+        @Schema(type = "LocalDateTime", example = "2023-12-22 23:51:45.848882", description = "알림이 생성된 DateTime을 출력합니다.")
+        private LocalDateTime dateTime;
+    }
+}

--- a/src/main/java/depth/jeonsilog/domain/alarm/dto/AlarmResponseDto.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/dto/AlarmResponseDto.java
@@ -25,7 +25,7 @@ public class AlarmResponseDto {
         @Schema(type = "long", example = "1", description = "클릭 시 페이지 이동에 필요한 ID를 clickId 로 설정한다.")
         private Long clickId;
 
-        @Schema(type = "string", example = "https://..", description = "이미지 url을 출력한다.")
+        @Schema(type = "string", example = "https://..", description = "프로필 / 전시회 이미지 url을 출력한다.")
         private String imgUrl;
 
         @Schema(type = "string", example = "루피 님이 나를 팔로우해요", description = "알림 내용을 출력합니다.")

--- a/src/main/java/depth/jeonsilog/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/presentation/AlarmController.java
@@ -2,7 +2,7 @@ package depth.jeonsilog.domain.alarm.presentation;
 
 
 import depth.jeonsilog.domain.alarm.application.AlarmService;
-import depth.jeonsilog.domain.calendar.dto.CalendarResponseDto;
+import depth.jeonsilog.domain.alarm.dto.AlarmResponseDto;
 import depth.jeonsilog.global.config.security.token.CurrentUser;
 import depth.jeonsilog.global.config.security.token.UserPrincipal;
 import depth.jeonsilog.global.payload.ErrorResponse;
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,16 +29,27 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
-//    @Operation(summary = "타입별 알림 목록 조회", description = "타입별 알림 목록을 조회합니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = .class)))}),
-//            @ApiResponse(responseCode = "400", description = "조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
-//    })
-//    @GetMapping("/{date}")
-//    public ResponseEntity<?> deleteCalendar(
-//            @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-//            @Parameter(description = "조회할 년/월을 yyyymm 형태로 입력해주세요", required = true) @PathVariable String date
-//    ) {
-//        return alarmService.getMyPhotoCalendar(userPrincipal, date);
-//    }
+    @Operation(summary = "활동 알림 목록 조회", description = "활동 알림 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = AlarmResponseDto.AlarmRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/activity")
+    public ResponseEntity<?> getActivityAlarmList(
+            @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return alarmService.getActivityAlarmList(userPrincipal);
+    }
+
+    @Operation(summary = "전시 알림 목록 조회", description = "전시 알림 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = AlarmResponseDto.AlarmRes.class)))}),
+            @ApiResponse(responseCode = "400", description = "조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+    })
+    @GetMapping("/exhibition")
+    public ResponseEntity<?> getExhibitionAlarmList(
+            @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return alarmService.getExhibitionAlarmList(userPrincipal);
+    }
 }

--- a/src/main/java/depth/jeonsilog/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/presentation/AlarmController.java
@@ -1,0 +1,44 @@
+package depth.jeonsilog.domain.alarm.presentation;
+
+
+import depth.jeonsilog.domain.alarm.application.AlarmService;
+import depth.jeonsilog.domain.calendar.dto.CalendarResponseDto;
+import depth.jeonsilog.global.config.security.token.CurrentUser;
+import depth.jeonsilog.global.config.security.token.UserPrincipal;
+import depth.jeonsilog.global.payload.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Alarm API", description = "알림 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/alarms")
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+//    @Operation(summary = "타입별 알림 목록 조회", description = "타입별 알림 목록을 조회합니다.")
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "조회 성공", content = {@Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = .class)))}),
+//            @ApiResponse(responseCode = "400", description = "조회 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
+//    })
+//    @GetMapping("/{date}")
+//    public ResponseEntity<?> deleteCalendar(
+//            @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+//            @Parameter(description = "조회할 년/월을 yyyymm 형태로 입력해주세요", required = true) @PathVariable String date
+//    ) {
+//        return alarmService.getMyPhotoCalendar(userPrincipal, date);
+//    }
+}

--- a/src/main/java/depth/jeonsilog/domain/follow/application/FollowService.java
+++ b/src/main/java/depth/jeonsilog/domain/follow/application/FollowService.java
@@ -1,5 +1,6 @@
 package depth.jeonsilog.domain.follow.application;
 
+import depth.jeonsilog.domain.alarm.application.AlarmService;
 import depth.jeonsilog.domain.follow.converter.FollowConverter;
 import depth.jeonsilog.domain.follow.domain.Follow;
 import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
@@ -15,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,6 +27,7 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserService userService;
+    private final AlarmService alarmService;
 
     // 팔로우하기
     @Transactional
@@ -38,6 +39,8 @@ public class FollowService {
 
         Follow follow = FollowConverter.toFollow(findUser, followUser);
         followRepository.save(follow);
+
+        alarmService.makeFollowAlarm(follow);
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(
                 Message.builder().message("[" + followUser.getNickname() + "]님을 팔로우했습니다.").build());

--- a/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestRepository.java
@@ -1,5 +1,6 @@
 package depth.jeonsilog.domain.interest.domain.repository;
 
+import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
 import depth.jeonsilog.domain.interest.domain.Interest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -13,4 +14,6 @@ public interface InterestRepository extends JpaRepository<Interest, Long> {
     Optional<Interest> findByUserIdAndExhibitionId(Long userId, Long exhibitionId);
 
     List<Interest> findAllByUserId(Long userId);
+
+    List<Interest> findByExhibition_OperatingKeyword(OperatingKeyword operatingKeyword);
 }

--- a/src/main/java/depth/jeonsilog/domain/rating/application/RatingService.java
+++ b/src/main/java/depth/jeonsilog/domain/rating/application/RatingService.java
@@ -1,5 +1,6 @@
 package depth.jeonsilog.domain.rating.application;
 
+import depth.jeonsilog.domain.alarm.application.AlarmService;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
 import depth.jeonsilog.domain.rating.converter.RatingConverter;
@@ -29,6 +30,7 @@ public class RatingService {
     private final RatingRepository ratingRepository;
     private final ExhibitionRepository exhibitionRepository;
     private final UserService userService;
+    private final AlarmService alarmService;
 
     // 별점 등록
     @Transactional
@@ -45,6 +47,8 @@ public class RatingService {
 
         Double updateRate = calculateRate(exhibition.get());
         exhibition.get().updateRate(updateRate);
+
+        alarmService.makeRatingAlarm(rating);
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(Message.builder().message("별점을 등록했습니다.").build());
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
+++ b/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
@@ -1,5 +1,6 @@
 package depth.jeonsilog.domain.reply.application;
 
+import depth.jeonsilog.domain.alarm.application.AlarmService;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.reply.converter.ReplyConverter;
 import depth.jeonsilog.domain.reply.domain.Reply;
@@ -8,7 +9,6 @@ import depth.jeonsilog.domain.reply.dto.ReplyRequestDto;
 import depth.jeonsilog.domain.reply.dto.ReplyResponseDto;
 import depth.jeonsilog.domain.review.application.ReviewService;
 import depth.jeonsilog.domain.review.domain.Review;
-import depth.jeonsilog.domain.review.domain.repository.ReviewRepository;
 import depth.jeonsilog.domain.user.application.UserService;
 import depth.jeonsilog.domain.user.domain.User;
 import depth.jeonsilog.global.DefaultAssert;
@@ -32,10 +32,9 @@ import java.util.Optional;
 public class ReplyService {
 
     private final ReplyRepository replyRepository;
-    private final ReviewRepository reviewRepository;
-
     private final UserService userService;
     private final ReviewService reviewService;
+    private final AlarmService alarmService;
 
     // Description : 댓글 목록 조회
     public ResponseEntity<?> findReplyList(Integer page, Long reviewId) {
@@ -65,6 +64,8 @@ public class ReplyService {
         replyRepository.save(reply);
 
         review.updateNumReply(review.getNumReply() + 1);
+
+        alarmService.makeReplyAlarm(reply);
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(Message.builder().message("댓글을 작성했습니다.").build());
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
+++ b/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
@@ -1,6 +1,7 @@
 package depth.jeonsilog.domain.review.application;
 
 
+import depth.jeonsilog.domain.alarm.application.AlarmService;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
@@ -33,6 +34,7 @@ public class ReviewService {
     private final ExhibitionRepository exhibitionRepository;
     private final RatingRepository ratingRepository;
     private final UserService userService;
+    private final AlarmService alarmService;
 
     // 감상평 작성
     @Transactional
@@ -43,6 +45,8 @@ public class ReviewService {
 
         Review review = ReviewConverter.toReview(findUser, exhibition.get(), writeReviewReq.getContents());
         reviewRepository.save(review);
+
+        alarmService.makeReviewAlarm(review);
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(Message.builder().message("감상평을 작성했습니다.").build());
         return ResponseEntity.ok(apiResponse);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[FEAT]: PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 감상평, 댓글, 별점, 팔로우, 전시회에 따른 알림 생성
- [x] 활동 알림 목록 조회 API 
- [x] 전시 알림 목록 조회 API

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 알림 조회 API는 두 개로 나누었습니다.
- 전시 알림 조회 - 매일 자정에 체크하도록 해놓았습니다. 기획팀과 논의 후 시간 변경 가능성 있습니다.
- 원래 알림생성자(송신자) 데이터는 DB에 저장하지 않으려 했는데 그렇게 될 경우 조회 시 너무 많은 테이블에 Join해야 한다는 점이 문제였습니다. senderId로 알림생성자의 유저ID를 저장하겠습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->


## 주의사항
<!-- 이슈를 닫기 위한 이슈 번호를 적어주세요! -->
Closes #36 
