### PR TITLE
🐛 [FIX]: 대면 회의 후 API 수정 사항 반영

### DIFF
--- a/src/main/java/depth/jeonsilog/domain/exhibition/domain/Exhibition.java
+++ b/src/main/java/depth/jeonsilog/domain/exhibition/domain/Exhibition.java
@@ -50,11 +50,15 @@ public class Exhibition extends BaseEntity {
     private Integer sequence;
 
     // update 메소드
-    public void updateExhibitionDetail(ExhibitionRequestDto.UpdateExhibitionDetailReq updateExhibitionDetailReq) {
+    public void updateExhibitionDetail(ExhibitionRequestDto.UpdateExhibitionDetailReq updateExhibitionDetailReq, String imageUrl) {
         this.name = updateExhibitionDetailReq.getExhibitionName();
         this.operatingKeyword = updateExhibitionDetailReq.getOperatingKeyword();
         this.priceKeyword = updateExhibitionDetailReq.getPriceKeyword();
         this.information = updateExhibitionDetailReq.getInformation();
+
+        if (updateExhibitionDetailReq.getIsImageChange()) { // 이미지 변경하는 경우
+            this.imageUrl = imageUrl;
+        }
     }
 
     public void updateRate(Double rate) {

--- a/src/main/java/depth/jeonsilog/domain/exhibition/domain/repository/ExhibitionRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/exhibition/domain/repository/ExhibitionRepository.java
@@ -17,6 +17,8 @@ public interface ExhibitionRepository extends JpaRepository<Exhibition, Long> {
     @EntityGraph(attributePaths = {"place"})
     Page<Exhibition> findByNameContaining(Pageable pageable, String searchWord);
 
+    Page<Exhibition> findByNameContainingOrPlace_AddressContaining(Pageable pageable, String searchWord, String searchWord2);
+
     Page<Exhibition> findByPlace(Pageable pageable, Place place);
 
 }

--- a/src/main/java/depth/jeonsilog/domain/exhibition/dto/ExhibitionRequestDto.java
+++ b/src/main/java/depth/jeonsilog/domain/exhibition/dto/ExhibitionRequestDto.java
@@ -28,6 +28,9 @@ public class ExhibitionRequestDto {
         @Size(max = 1000, message = "1000자 이하로만 작성 가능합니다.")
         private String information;
 
+        @Schema(type = "Boolean", example = "false", description = "전시회 포스터 이미지 변동 여부 입니다.")
+        private Boolean isImageChange;
+
         private PlaceRequestDto.UpdatePlaceWithExhibitionDetailReq updatePlaceInfo;
 
     }

--- a/src/main/java/depth/jeonsilog/domain/exhibition/presentation/ExhibitionController.java
+++ b/src/main/java/depth/jeonsilog/domain/exhibition/presentation/ExhibitionController.java
@@ -19,6 +19,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "Exhibition API", description = "Exhibition 관련 API입니다.")
 @RequiredArgsConstructor
@@ -89,13 +92,14 @@ public class ExhibitionController {
     })
     @PatchMapping
     public ResponseEntity<?> updateExhibitionDetail(
-            @Parameter(description = "Schemas의 UpdateExhibitionDetailReq와 UpdatePlaceWithExhibitionDetailReq를 참고해주세요", required = true) @RequestBody ExhibitionRequestDto.UpdateExhibitionDetailReq updateExhibitionDetailReq
-            ) {
-        return exhibitionService.updateExhibitionDetail(updateExhibitionDetailReq);
+            @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "Schemas의 UpdateExhibitionDetailReq와 UpdatePlaceWithExhibitionDetailReq를 참고해주세요", required = true) @RequestPart("updateExhibitionDetailReq") ExhibitionRequestDto.UpdateExhibitionDetailReq updateExhibitionDetailReq,
+            @Parameter(description = "등록할 전시회 포스터 이미지 파일을 입력해주세요.") @RequestPart(value = "img", required = false) MultipartFile img
+            ) throws IOException {
+        return exhibitionService.updateExhibitionDetail(userPrincipal, updateExhibitionDetailReq, img);
     }
 
     // Description : 전시회 id로 전시회 포스터 조회
-    // 전시회 포스터는 하나라서.. 그 화면의 필요 여부 확인이 필요하긴 하나..
     @Operation(summary = "전시회 포스터 조회", description = "전시회 포스터를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ExhibitionResponseDto.PosterRes.class))}),

--- a/src/main/java/depth/jeonsilog/domain/place/domain/Place.java
+++ b/src/main/java/depth/jeonsilog/domain/place/domain/Place.java
@@ -13,11 +13,6 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Place extends BaseEntity {
 
-    /**
-     * TODO : address 나눠야 하나 ?
-     * TODO : OPEN API 응답 보고, 우리 피그마 보고 --> 시/군/구 등 나눌 필요 있다면 나누는 것으로 !
-     */
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -37,9 +32,8 @@ public class Place extends BaseEntity {
 
     // update 메소드
     public void updatePlaceWithExhibitionDetail(PlaceRequestDto.UpdatePlaceWithExhibitionDetailReq updatePlaceWithExhibitionDetailReq) {
+        this.name = updatePlaceWithExhibitionDetailReq.getPlaceName();
         this.address = updatePlaceWithExhibitionDetailReq.getPlaceAddress();
-        this.operatingTime = updatePlaceWithExhibitionDetailReq.getOperatingTime();
-        this.closedDays = updatePlaceWithExhibitionDetailReq.getClosedDays();
         this.tel = updatePlaceWithExhibitionDetailReq.getPlaceTel();
         this.homePage = updatePlaceWithExhibitionDetailReq.getPlaceHomePage();
     }

--- a/src/main/java/depth/jeonsilog/domain/place/dto/PlaceRequestDto.java
+++ b/src/main/java/depth/jeonsilog/domain/place/dto/PlaceRequestDto.java
@@ -12,19 +12,16 @@ public class PlaceRequestDto {
         @Schema(type = "Long", example = "1", description = "전시 공간 ID입니다.")
         private Long placeId;
 
+        @Schema(type = "String", example = "예술의전당(한가람미술관)", description = "전시 공간 이름입니다.")
+        private String placeName;
+
         @Schema(type = "String", example = "서울특별시 송파구 올림픽로 300 롯데월드몰 8층 롯데콘서트홀", description = "전시 공간 주소입니다.")
         private String placeAddress;
-
-        @Schema(type = "String", example = "~~~ ~~~", description = "전시 공간 운영 시간입니다.")
-        private String operatingTime;
-
-        @Schema(type = "ClosedDays", example = "MONDAY", description = "전시 공간 휴관일입니다.")
-        private ClosedDays closedDays;
 
         @Schema(type = "String", example = "031-590-4358", description = "전시 공간 전화번호입니다.")
         private String placeTel;
 
-        @Schema(type = "String", example = "\thttps://culture.nyj.go.kr/home/", description = "전시 공간 전화번호입니다.")
+        @Schema(type = "String", example = "\thttps://culture.nyj.go.kr/home/", description = "전시 공간 홈페이지입니다.")
         private String placeHomePage;
 
     }

--- a/src/main/java/depth/jeonsilog/domain/rating/domain/Rating.java
+++ b/src/main/java/depth/jeonsilog/domain/rating/domain/Rating.java
@@ -32,6 +32,11 @@ public class Rating extends BaseEntity {
         this.rate = rate;
     }
 
+    // 유저 삭제 시 사용 (null)
+    public void deleteUser() {
+        this.user = null;
+    }
+
     @Builder
     public Rating(Long id, User user, Exhibition exhibition, Double rate) {
         this.id = id;

--- a/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
+++ b/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
@@ -10,6 +10,7 @@ import depth.jeonsilog.domain.reply.dto.ReplyResponseDto;
 import depth.jeonsilog.domain.review.application.ReviewService;
 import depth.jeonsilog.domain.review.domain.Review;
 import depth.jeonsilog.domain.user.application.UserService;
+import depth.jeonsilog.domain.user.domain.Role;
 import depth.jeonsilog.domain.user.domain.User;
 import depth.jeonsilog.global.DefaultAssert;
 import depth.jeonsilog.global.config.security.token.UserPrincipal;
@@ -79,7 +80,8 @@ public class ReplyService {
         Reply reply = validateReplyById(replyId);
         Review review = reply.getReview();
 
-        DefaultAssert.isTrue(user.equals(reply.getUser()), "해당 댓글의 작성자만 삭제할 수 있습니다.");
+        DefaultAssert.isTrue(user.equals(reply.getUser()) || user.getRole().equals(Role.ADMIN)
+                , "해당 댓글의 작성자 혹은 관리자만 삭제할 수 있습니다.");
         reply.updateStatus(Status.DELETE);
 
         review.updateNumReply(review.getNumReply() - 1);

--- a/src/main/java/depth/jeonsilog/domain/reply/domain/repository/ReplyRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/reply/domain/repository/ReplyRepository.java
@@ -7,9 +7,15 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReplyRepository extends JpaRepository<Reply, Long> {
 
     Page<Reply> findByReview(PageRequest pageRequest, Review review);
+
+    List<Reply> findByReview(Review review);
+
+    List<Reply> findAllByUserId(Long userId);
 
 }

--- a/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
+++ b/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
@@ -6,12 +6,15 @@ import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
 import depth.jeonsilog.domain.rating.domain.repository.RatingRepository;
+import depth.jeonsilog.domain.reply.domain.Reply;
+import depth.jeonsilog.domain.reply.domain.repository.ReplyRepository;
 import depth.jeonsilog.domain.review.converter.ReviewConverter;
 import depth.jeonsilog.domain.review.domain.Review;
 import depth.jeonsilog.domain.review.domain.repository.ReviewRepository;
 import depth.jeonsilog.domain.review.dto.ReviewRequestDto;
 import depth.jeonsilog.domain.review.dto.ReviewResponseDto;
 import depth.jeonsilog.domain.user.application.UserService;
+import depth.jeonsilog.domain.user.domain.Role;
 import depth.jeonsilog.domain.user.domain.User;
 import depth.jeonsilog.global.DefaultAssert;
 import depth.jeonsilog.global.config.security.token.UserPrincipal;
@@ -33,6 +36,8 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ExhibitionRepository exhibitionRepository;
     private final RatingRepository ratingRepository;
+    private final ReplyRepository replyRepository;
+
     private final UserService userService;
     private final AlarmService alarmService;
 
@@ -56,11 +61,16 @@ public class ReviewService {
     @Transactional
     public ResponseEntity<?> deleteReview(UserPrincipal userPrincipal, Long reviewId) {
         User findUser = userService.validateUserByToken(userPrincipal);
-        Optional<Review> review = reviewRepository.findById(reviewId);
-        DefaultAssert.isTrue(review.isPresent(), "Review id가 올바르지 않습니다.");
-        Review findReview = review.get();
+        Review findReview = validateReviewById(reviewId);
 
-        DefaultAssert.isTrue(findUser.equals(findReview.getUser()), "해당 리뷰의 작성자만 삭제할 수 있습니다.");
+        DefaultAssert.isTrue(findUser.equals(findReview.getUser()) || findUser.getRole().equals(Role.ADMIN)
+                , "해당 리뷰의 작성자 혹은 관리자만 삭제할 수 있습니다.");
+
+        List<Reply> replyList = replyRepository.findByReview(findReview);
+        for (Reply reply : replyList) {
+            reply.updateStatus(Status.DELETE);
+        }
+
         findReview.updateStatus(Status.DELETE);
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(Message.builder().message("감상평을 삭제했습니다.").build());

--- a/src/main/java/depth/jeonsilog/domain/user/application/UserService.java
+++ b/src/main/java/depth/jeonsilog/domain/user/application/UserService.java
@@ -4,6 +4,14 @@ import depth.jeonsilog.domain.auth.domain.Token;
 import depth.jeonsilog.domain.auth.domain.repository.TokenRepository;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
+import depth.jeonsilog.domain.interest.domain.Interest;
+import depth.jeonsilog.domain.interest.domain.repository.InterestRepository;
+import depth.jeonsilog.domain.rating.domain.Rating;
+import depth.jeonsilog.domain.rating.domain.repository.RatingRepository;
+import depth.jeonsilog.domain.reply.domain.Reply;
+import depth.jeonsilog.domain.reply.domain.repository.ReplyRepository;
+import depth.jeonsilog.domain.review.domain.Review;
+import depth.jeonsilog.domain.review.domain.repository.ReviewRepository;
 import depth.jeonsilog.domain.s3.application.S3Uploader;
 import depth.jeonsilog.domain.user.converter.UserConverter;
 import depth.jeonsilog.domain.user.domain.User;
@@ -32,6 +40,12 @@ public class UserService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final TokenRepository tokenRepository;
+
+    private final ReviewRepository reviewRepository;
+    private final ReplyRepository replyRepository;
+    private final RatingRepository ratingRepository;
+    private final InterestRepository interestRepository;
+
     private final S3Uploader s3Uploader;
 
     // 토큰으로 본인 정보 조회
@@ -105,6 +119,31 @@ public class UserService {
     public ResponseEntity<?> deleteUser(UserPrincipal userPrincipal) {
 
         User findUser = validateUserByToken(userPrincipal);
+        Long userId = findUser.getId();
+
+        // 즐겨찾기, 별점, 감상평, 댓글 DELETE 처리
+        List<Review> reviews = reviewRepository.findAllByUserId(userId);
+        List<Rating> ratings = ratingRepository.findAllByUserId(userId);
+        List<Interest> interests = interestRepository.findAllByUserId(userId);
+
+        // review의 replies도
+        for (Review review : reviews) {
+            List<Reply> replyByReview = replyRepository.findByReview(review);
+            replyRepository.deleteAll(replyByReview);
+        }
+        // 얘만 여기 있는 이유 : 바로 위에서 지운 reply와 겹치지 않도록 하기 위함
+        List<Reply> replyByUser = replyRepository.findAllByUserId(userId);
+        replyRepository.deleteAll(replyByUser);
+
+        // soft delete를 통한 별점 변동 x
+        for (Rating rating : ratings) {
+            rating.updateStatus(Status.DELETE);
+            rating.deleteUser();
+        }
+
+        reviewRepository.deleteAll(reviews);
+        interestRepository.deleteAll(interests);
+
         userRepository.delete(findUser); // hard delete
 
         Optional<Token> token = tokenRepository.findByUserEmail(userPrincipal.getEmail());

--- a/src/main/java/depth/jeonsilog/domain/user/domain/User.java
+++ b/src/main/java/depth/jeonsilog/domain/user/domain/User.java
@@ -1,13 +1,19 @@
 package depth.jeonsilog.domain.user.domain;
 
+import depth.jeonsilog.domain.alarm.domain.Alarm;
+import depth.jeonsilog.domain.calendar.domain.Calendar;
 import depth.jeonsilog.domain.common.BaseEntity;
+import depth.jeonsilog.domain.follow.domain.Follow;
+import depth.jeonsilog.domain.report.domain.Report;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Where;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -43,6 +49,22 @@ public class User extends BaseEntity {
     private Provider provider;
     // 카카오 고유 ID
     private String providerId;
+
+    // CASCADE 추가
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Follow> followers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "follow", cascade = CascadeType.REMOVE)
+    private List<Follow> followings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Calendar> calendars = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Report> reports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Alarm> alarms = new ArrayList<>();
 
     // update 메서드
     public void updateNickname(String nickname) {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[FEAT]: PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 유저 탈퇴 : 관련된 다른 건 다 삭제하고 전시회 평균 별점은 냅두기
- [x] 관리자 페이지 전시회 이미지 포스터 수정 및 삭제 부분 추가
- [x] 관리자용 감상평 삭제, 댓글 삭제를 위한 DefaultAssert 검증 로직 수정 (ADMIN) 
- [x] 전시회 상세 정보 수정 : 관리자 체크 로직 추가
- [x] 감상평 삭제 시 댓글 삭제
- [x] 전시회 검색 → 이름 + 주소로 검색되게 수정

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
수정 파일이 많습니다.. 간단할 줄 알았던 것들이 사소한 부분에서 걸려서 생각보다 오래 걸렸습니다. 얽혀 있는 것들이 많기에 이해가 어려울 수 있어, 노션에도 적어 놓았고, 이유가 궁금한 부분은 말씀해주시면 설명하겠습니다.

1. 유저 탈퇴 - 팔로우, 캘린더, 알림, 신고는 Cascade.REMOVE 적용했습니다.

2. 관리자 페이지 : 이미지 포스터 수정 및 삭제 추가 - 이미지 변경 여부를 req로 받았습니다.

3. 감상평 삭제 시 댓글 삭제 - Reply 자체는 Soft Delete를 기본으로 하기에, 여기선 Soft Delete를 적용했습니다.

4. 전시회 포스터 이미지 저장을 위한 S3 디렉토리를 추가했습니다.

5. 유저 탈퇴 시 프로필 이미지 S3에서 삭제 - 까먹었습니다.. 추가하겠습니다
6. 유저 탈퇴 시 캘린더 이미지 S3에서 삭제 - 에러는 없기에 괜찮지만.. 고려 사항이 많아, 후순위로 미루겠습니다..

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->


## 주의사항
<!-- 이슈를 닫기 위한 이슈 번호를 적어주세요! -->
Closes #40 
