### PR TITLE
:sparkles: [FEAT]: 관심 전시회 중 기록하지 않은 전시회 대상으로 종료 임박 알림

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,13 @@ dependencies {
     //fcm
     implementation 'com.google.firebase:firebase-admin:6.8.1'
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+
+    //query dsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    implementation 'com.querydsl:querydsl-sql:5.0.0'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmCreateService.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmCreateService.java
@@ -1,0 +1,212 @@
+package depth.jeonsilog.domain.alarm.application;
+
+import depth.jeonsilog.domain.alarm.converter.AlarmConverter;
+import depth.jeonsilog.domain.alarm.domain.Alarm;
+import depth.jeonsilog.domain.alarm.domain.AlarmType;
+import depth.jeonsilog.domain.alarm.domain.repository.AlarmRepository;
+import depth.jeonsilog.domain.exhibition.domain.Exhibition;
+import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
+import depth.jeonsilog.domain.fcm.application.FcmService;
+import depth.jeonsilog.domain.follow.domain.Follow;
+import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
+import depth.jeonsilog.domain.interest.domain.Interest;
+import depth.jeonsilog.domain.interest.domain.repository.InterestRepository;
+import depth.jeonsilog.domain.rating.domain.Rating;
+import depth.jeonsilog.domain.reply.domain.Reply;
+import depth.jeonsilog.domain.review.domain.Review;
+import depth.jeonsilog.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AlarmCreateService {
+
+    private final AlarmRepository alarmRepository;
+    private final FollowRepository followRepository;
+    private final InterestRepository interestRepository;
+    private final FcmService fcmService;
+
+    private static String BEFORE_7DAYS = "전시 시작까지 7일 남았어요";
+    private static String BEFORE_3DAYS = "전시 시작까지 3일 남았어요";
+    private static String BEFORE_1DAYS = "전시 시작까지 1일 남았어요";
+    private static String END_7DAYS = "전시 종료까지 7일 남았어요";
+    private static String END_3DAYS = "전시 종료까지 3일 남았어요";
+    private static String END_1DAYS = "전시 종료까지 1일 남았어요";
+
+    // TODO: 팔로잉한 사람의 new 감상평 -> 알림 생성
+    @Transactional
+    public void makeReviewAlarm(Review review) throws IOException {
+        List<Follow> follows = followRepository.findAllByFollow(review.getUser());
+        for (Follow follow : follows) {
+            User receiver = follow.getUser();
+            User sender = follow.getFollow();
+
+            Alarm alarm = Alarm.builder()
+                    .user(receiver)
+                    .senderId(sender.getId())
+                    .alarmType(AlarmType.REVIEW)
+                    .targetId(review.getId())
+                    .clickId(review.getId())
+                    .isChecked(false)
+                    .build();
+            alarmRepository.save(alarm);
+
+            if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
+            fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 감상평을 남겼어요");
+        }
+    }
+
+    // TODO: 팔로잉한 사람의 new 별점 -> 알림 생성
+    @Transactional
+    public void makeRatingAlarm(Rating rating) throws IOException {
+        List<Follow> follows = followRepository.findAllByFollow(rating.getUser());
+        for (Follow follow : follows) {
+            User receiver = follow.getUser();
+            User sender = follow.getFollow();
+
+            Alarm alarm = Alarm.builder()
+                    .user(receiver)
+                    .senderId(sender.getId())
+                    .alarmType(AlarmType.RATING)
+                    .targetId(rating.getId())
+                    .clickId(rating.getExhibition().getId())
+                    .isChecked(false)
+                    .build();
+            alarmRepository.save(alarm);
+
+            if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
+            fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 별점을 남겼어요");
+        }
+    }
+
+    // TODO: 나의 감상평에 달린 댓글 -> 알림 생성
+    @Transactional
+    public void makeReplyAlarm(Reply reply) throws IOException {
+        User receiver = reply.getReview().getUser();
+        User sender = reply.getUser();
+        if (receiver.equals(sender)) {
+            log.info("알림의 sender와 receiver가 동일 인물입니다.");
+            return;
+        }
+
+        Alarm alarm = Alarm.builder()
+                .user(receiver)
+                .senderId(sender.getId())
+                .alarmType(AlarmType.REPLY)
+                .targetId(reply.getId())
+                .clickId(reply.getReview().getId())
+                .isChecked(false)
+                .build();
+        alarmRepository.save(alarm);
+
+        if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
+        fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 댓글을 남겼어요");
+    }
+
+    // TODO: 나를 팔로우 -> 알림 생성
+    @Transactional
+    public void makeFollowAlarm(Follow follow) throws IOException {
+        User receiver = follow.getFollow();
+        User sender = follow.getUser();
+
+        Alarm alarm = Alarm.builder()
+                .user(receiver)
+                .senderId(sender.getId())
+                .alarmType(AlarmType.FOLLOW)
+                .targetId(follow.getId())
+                .clickId(follow.getUser().getId())
+                .isChecked(false)
+                .build();
+        alarmRepository.save(alarm);
+
+        if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
+        fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 나를 팔로우해요");
+    }
+
+    // TODO: 관심 전시회 시작 전 -> 알림 생성
+    @Transactional
+    @Scheduled(cron = "0 0 9 * * *") // 오전 9시에 실행
+    public void makeExhibitionAlarm() {
+        List<Interest> interests = interestRepository.findByExhibition_OperatingKeyword(OperatingKeyword.BEFORE_DISPLAY);
+
+        LocalDate currentDate = LocalDate.now();
+        log.info("현재 날짜: " + currentDate);
+        for (Interest interest : interests) {
+            Exhibition exhibition = interest.getExhibition();
+            User receiver = interest.getUser();
+
+            LocalDate startDate = LocalDate.parse(exhibition.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+            log.info("전시회 시작 날짜: " + startDate);
+
+            long daysDifference = ChronoUnit.DAYS.between(currentDate, startDate);
+            if (daysDifference != 7 && daysDifference != 3 && daysDifference != 1) continue;
+            if (checkDuplicateAlarm(receiver.getId(), exhibition.getId(), getBeforeAlarmType(daysDifference))) continue;
+
+            Alarm alarm = AlarmConverter.toExhibitionAlarm(interest, getBeforeAlarmType(daysDifference));
+            alarmRepository.save(alarm);
+
+            if (receiver.getIsRecvExhibition() && receiver.getFcmToken() != null){
+                fcmService.makeExhibitionAlarm(receiver.getFcmToken(), exhibition.getName(), alarm.getContents());
+            }
+        }
+    }
+
+    // TODO: 관심 전시회 중 별점, 리뷰 남기지 않은 전시회에 한해 종료 임박 알림 생성
+    @Transactional
+    @Scheduled(cron = "0 0 9 * * *") // 오전 9시에 실행
+    public void makeExhibitionEndAlarm() {
+        List<Interest> interests = interestRepository.findInterestsByUserAndExhibitionWithoutRatingAndReview();
+        LocalDate currentDate = LocalDate.now();
+
+        for (Interest interest : interests) {
+            User receiver = interest.getUser();
+            Exhibition exhibition = interest.getExhibition();
+
+            LocalDate endDate = LocalDate.parse(exhibition.getEndDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+            long daysDifference = ChronoUnit.DAYS.between(currentDate, endDate);
+            if (daysDifference != 7 && daysDifference != 3 && daysDifference != 1) continue;
+            if (checkDuplicateAlarm(receiver.getId(), exhibition.getId(), getEndAlarmType(daysDifference))) continue;
+
+            Alarm alarm = AlarmConverter.toExhibitionAlarm(interest, getEndAlarmType(daysDifference));
+            alarmRepository.save(alarm);
+
+            if (receiver.getIsRecvExhibition() && receiver.getFcmToken() != null){
+                fcmService.makeExhibitionAlarm(receiver.getFcmToken(), exhibition.getName(), alarm.getContents());
+            }
+        }
+    }
+
+    public boolean checkDuplicateAlarm(Long userId, Long targetId, String contents) {
+        return alarmRepository.existsByUserIdAndTargetIdAndContents(userId, targetId, contents);
+    }
+
+    private String getBeforeAlarmType(long daysDifference) {
+        return switch ((int) daysDifference) {
+            case 7 -> BEFORE_7DAYS;
+            case 3 -> BEFORE_3DAYS;
+            case 1 -> BEFORE_1DAYS;
+            default -> "";
+        };
+    }
+
+    private String getEndAlarmType(long daysDifference) {
+        return switch ((int) daysDifference) {
+            case 7 -> END_7DAYS;
+            case 3 -> END_3DAYS;
+            case 1 -> END_1DAYS;
+            default -> "";
+        };
+    }
+}

--- a/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
+++ b/src/main/java/depth/jeonsilog/domain/alarm/application/AlarmService.java
@@ -6,16 +6,7 @@ import depth.jeonsilog.domain.alarm.domain.AlarmType;
 import depth.jeonsilog.domain.alarm.domain.repository.AlarmRepository;
 import depth.jeonsilog.domain.alarm.dto.AlarmResponseDto;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
-import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
 import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
-import depth.jeonsilog.domain.fcm.application.FcmService;
-import depth.jeonsilog.domain.follow.domain.Follow;
-import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
-import depth.jeonsilog.domain.interest.domain.Interest;
-import depth.jeonsilog.domain.interest.domain.repository.InterestRepository;
-import depth.jeonsilog.domain.rating.domain.Rating;
-import depth.jeonsilog.domain.reply.domain.Reply;
-import depth.jeonsilog.domain.review.domain.Review;
 import depth.jeonsilog.domain.user.application.UserService;
 import depth.jeonsilog.domain.user.domain.User;
 import depth.jeonsilog.domain.user.domain.repository.UserRepository;
@@ -29,14 +20,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -49,16 +35,9 @@ import java.util.Optional;
 public class AlarmService {
 
     private final AlarmRepository alarmRepository;
-    private final FollowRepository followRepository;
-    private final InterestRepository interestRepository;
     private final UserRepository userRepository;
     private final ExhibitionRepository exhibitionRepository;
     private final UserService userService;
-    private final FcmService fcmService;
-
-    private static String BEFORE_7DAYS = "전시 시작까지 7일 남았어요";
-    private static String BEFORE_3DAYS = "전시 시작까지 3일 남았어요";
-    private static String BEFORE_1DAYS = "전시 시작까지 1일 남았어요";
 
     // TODO: 활동 알림 목록 조회
     public ResponseEntity<?> getActivityAlarmList(Integer page, UserPrincipal userPrincipal) {
@@ -154,134 +133,5 @@ public class AlarmService {
 
         ApiResponse apiResponse = ApiResponse.toApiResponse(Message.builder().message("알림이 확인되었습니다.").build());
         return ResponseEntity.ok(apiResponse);
-    }
-
-    // TODO: 팔로잉한 사람의 new 감상평 -> 알림 생성
-    @Transactional
-    public void makeReviewAlarm(Review review) throws IOException {
-        List<Follow> follows = followRepository.findAllByFollow(review.getUser());
-        for (Follow follow : follows) {
-            User receiver = follow.getUser();
-            User sender = follow.getFollow();
-
-            Alarm alarm = Alarm.builder()
-                    .user(receiver)
-                    .senderId(sender.getId())
-                    .alarmType(AlarmType.REVIEW)
-                    .targetId(review.getId())
-                    .clickId(review.getId())
-                    .isChecked(false)
-                    .build();
-            alarmRepository.save(alarm);
-
-            if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
-            fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 감상평을 남겼어요");
-        }
-    }
-
-    // TODO: 팔로잉한 사람의 new 별점 -> 알림 생성
-    @Transactional
-    public void makeRatingAlarm(Rating rating) throws IOException {
-        List<Follow> follows = followRepository.findAllByFollow(rating.getUser());
-        for (Follow follow : follows) {
-            User receiver = follow.getUser();
-            User sender = follow.getFollow();
-
-            Alarm alarm = Alarm.builder()
-                    .user(receiver)
-                    .senderId(sender.getId())
-                    .alarmType(AlarmType.RATING)
-                    .targetId(rating.getId())
-                    .clickId(rating.getExhibition().getId())
-                    .isChecked(false)
-                    .build();
-            alarmRepository.save(alarm);
-
-            if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
-            fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 별점을 남겼어요");
-        }
-    }
-
-    // TODO: 나의 감상평에 달린 댓글 -> 알림 생성
-    @Transactional
-    public void makeReplyAlarm(Reply reply) throws IOException {
-        User receiver = reply.getReview().getUser();
-        User sender = reply.getUser();
-        if (receiver.equals(sender)) {
-            log.info("알림의 sender와 receiver가 동일 인물입니다.");
-            return;
-        }
-
-        Alarm alarm = Alarm.builder()
-                .user(receiver)
-                .senderId(sender.getId())
-                .alarmType(AlarmType.REPLY)
-                .targetId(reply.getId())
-                .clickId(reply.getReview().getId())
-                .isChecked(false)
-                .build();
-        alarmRepository.save(alarm);
-
-        if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
-        fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 댓글을 남겼어요");
-    }
-
-    // TODO: 나를 팔로우 -> 알림 생성
-    @Transactional
-    public void makeFollowAlarm(Follow follow) throws IOException {
-        User receiver = follow.getFollow();
-        User sender = follow.getUser();
-
-        Alarm alarm = Alarm.builder()
-                .user(receiver)
-                .senderId(sender.getId())
-                .alarmType(AlarmType.FOLLOW)
-                .targetId(follow.getId())
-                .clickId(follow.getUser().getId())
-                .isChecked(false)
-                .build();
-        alarmRepository.save(alarm);
-
-        if (!receiver.getIsRecvActive() || receiver.getFcmToken() == null) return;
-        fcmService.makeActiveAlarm(receiver.getFcmToken(), sender.getNickname() + " 님이 나를 팔로우해요");
-    }
-
-    // TODO: 관심 전시회 시작 전 -> 알림 생성
-    @Transactional
-    @Scheduled(cron = "0 0 9 * * *") // 오전 9시에 실행
-    public void makeExhibitionAlarm() {
-        List<Interest> interests = interestRepository.findByExhibition_OperatingKeyword(OperatingKeyword.BEFORE_DISPLAY);
-
-        LocalDate currentDate = LocalDate.now();
-        log.info("현재 날짜: " + currentDate);
-        for (Interest interest : interests) {
-            Exhibition exhibition = interest.getExhibition();
-            User receiver = interest.getUser();
-
-            LocalDate targetDate = LocalDate.parse(exhibition.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
-            log.info("전시회 시작 날짜: " + targetDate);
-
-            Alarm alarm = null;
-            long daysDifference = ChronoUnit.DAYS.between(currentDate, targetDate);
-            if (daysDifference == 7) {
-                if (checkDuplicateAlarm(receiver.getId(), exhibition.getId(), BEFORE_7DAYS)) continue;
-                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_7DAYS);
-            } else if (daysDifference == 3) {
-                if (checkDuplicateAlarm(receiver.getId(), exhibition.getId(), BEFORE_3DAYS)) continue;
-                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_3DAYS);
-            } else if (daysDifference == 1) {
-                if (checkDuplicateAlarm(receiver.getId(), exhibition.getId(), BEFORE_1DAYS)) continue;
-                alarm = AlarmConverter.toExhibitionAlarm(interest, BEFORE_1DAYS);
-            }
-            assert alarm != null;
-            alarmRepository.save(alarm);
-
-            if (!receiver.getIsRecvExhibition() || receiver.getFcmToken() == null) return;
-            fcmService.makeExhibitionAlarm(receiver.getFcmToken(), exhibition.getName(), alarm.getContents());
-        }
-    }
-
-    public boolean checkDuplicateAlarm(Long userId, Long targetId, String contents) {
-        return alarmRepository.existsByUserIdAndTargetIdAndContents(userId, targetId, contents);
     }
 }

--- a/src/main/java/depth/jeonsilog/domain/follow/application/FollowService.java
+++ b/src/main/java/depth/jeonsilog/domain/follow/application/FollowService.java
@@ -1,6 +1,6 @@
 package depth.jeonsilog.domain.follow.application;
 
-import depth.jeonsilog.domain.alarm.application.AlarmService;
+import depth.jeonsilog.domain.alarm.application.AlarmCreateService;
 import depth.jeonsilog.domain.follow.converter.FollowConverter;
 import depth.jeonsilog.domain.follow.domain.Follow;
 import depth.jeonsilog.domain.follow.domain.repository.FollowRepository;
@@ -31,7 +31,7 @@ public class FollowService {
 
     private final FollowRepository followRepository;
     private final UserService userService;
-    private final AlarmService alarmService;
+    private final AlarmCreateService alarmService;
 
     // 팔로우하기
     @Transactional

--- a/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestQuerydslRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestQuerydslRepository.java
@@ -1,0 +1,10 @@
+package depth.jeonsilog.domain.interest.domain.repository;
+
+import depth.jeonsilog.domain.interest.domain.Interest;
+
+import java.util.List;
+
+public interface InterestQuerydslRepository {
+
+    List<Interest> findInterestsByUserAndExhibitionWithoutRatingAndReview();
+}

--- a/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestQuerydslRepositoryImpl.java
+++ b/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestQuerydslRepositoryImpl.java
@@ -1,0 +1,49 @@
+package depth.jeonsilog.domain.interest.domain.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
+import depth.jeonsilog.domain.exhibition.domain.QExhibition;
+import depth.jeonsilog.domain.interest.domain.Interest;
+import depth.jeonsilog.domain.interest.domain.QInterest;
+import depth.jeonsilog.domain.rating.domain.QRating;
+import depth.jeonsilog.domain.review.domain.QReview;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class InterestQuerydslRepositoryImpl implements InterestQuerydslRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Interest> findInterestsByUserAndExhibitionWithoutRatingAndReview() {
+        QInterest interest = QInterest.interest;
+        QRating rating = QRating.rating;
+        QReview review = QReview.review;
+        QExhibition exhibition = QExhibition.exhibition;
+
+        // 서브쿼리를 사용하여 해당 전시회와 사용자에 대한 평점과 리뷰의 존재 여부를 확인
+        BooleanExpression noRatings = JPAExpressions
+                .selectFrom(rating)
+                .where(rating.user.eq(interest.user),
+                        rating.exhibition.eq(interest.exhibition))
+                .notExists();
+
+        BooleanExpression noReviews = JPAExpressions
+                .selectFrom(review)
+                .where(review.user.eq(interest.user),
+                        review.exhibition.eq(interest.exhibition))
+                .notExists();
+
+        return queryFactory
+                .selectFrom(interest)
+                .join(interest.exhibition, exhibition)
+                .where(exhibition.operatingKeyword.eq(OperatingKeyword.ON_DISPLAY),
+                        noRatings,
+                        noReviews)
+                .fetch();
+    }
+}

--- a/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/interest/domain/repository/InterestRepository.java
@@ -2,7 +2,6 @@ package depth.jeonsilog.domain.interest.domain.repository;
 
 import depth.jeonsilog.domain.exhibition.domain.OperatingKeyword;
 import depth.jeonsilog.domain.interest.domain.Interest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface InterestRepository extends JpaRepository<Interest, Long> {
+public interface InterestRepository extends JpaRepository<Interest, Long>, InterestQuerydslRepository {
 
     Optional<Interest> findByUserIdAndExhibitionId(Long userId, Long exhibitionId);
 

--- a/src/main/java/depth/jeonsilog/domain/rating/application/RatingService.java
+++ b/src/main/java/depth/jeonsilog/domain/rating/application/RatingService.java
@@ -1,6 +1,6 @@
 package depth.jeonsilog.domain.rating.application;
 
-import depth.jeonsilog.domain.alarm.application.AlarmService;
+import depth.jeonsilog.domain.alarm.application.AlarmCreateService;
 import depth.jeonsilog.domain.exhibition.application.ExhibitionService;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.rating.converter.RatingConverter;
@@ -35,7 +35,7 @@ public class RatingService {
 
     private final ExhibitionService exhibitionService;
     private final UserService userService;
-    private final AlarmService alarmService;
+    private final AlarmCreateService alarmService;
 
     // 별점 등록
     @Transactional

--- a/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
+++ b/src/main/java/depth/jeonsilog/domain/reply/application/ReplyService.java
@@ -1,6 +1,6 @@
 package depth.jeonsilog.domain.reply.application;
 
-import depth.jeonsilog.domain.alarm.application.AlarmService;
+import depth.jeonsilog.domain.alarm.application.AlarmCreateService;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.reply.converter.ReplyConverter;
 import depth.jeonsilog.domain.reply.domain.Reply;
@@ -36,7 +36,7 @@ public class ReplyService {
     private final ReplyRepository replyRepository;
     private final UserService userService;
     private final ReviewService reviewService;
-    private final AlarmService alarmService;
+    private final AlarmCreateService alarmService;
 
     // Description : 댓글 목록 조회
     public ResponseEntity<?> findReplyList(Integer page, Long reviewId) {

--- a/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
+++ b/src/main/java/depth/jeonsilog/domain/review/application/ReviewService.java
@@ -1,11 +1,10 @@
 package depth.jeonsilog.domain.review.application;
 
 
-import depth.jeonsilog.domain.alarm.application.AlarmService;
+import depth.jeonsilog.domain.alarm.application.AlarmCreateService;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
-import depth.jeonsilog.domain.rating.application.RatingService;
 import depth.jeonsilog.domain.rating.domain.Rating;
 import depth.jeonsilog.domain.rating.domain.repository.RatingRepository;
 import depth.jeonsilog.domain.reply.domain.Reply;
@@ -48,8 +47,7 @@ public class ReviewService {
     private final ReplyRepository replyRepository;
 
     private final UserService userService;
-    private final AlarmService alarmService;
-    private final RatingService ratingService;
+    private final AlarmCreateService alarmService;
 
     // 감상평 작성
     @Transactional

--- a/src/main/java/depth/jeonsilog/global/config/QueryDslConfig.java
+++ b/src/main/java/depth/jeonsilog/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package depth.jeonsilog.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[FEAT]: PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 관심 전시회 중 기록하지 않은 전시회 대상으로 종료 임박 알림
- [x] AlarmService 분리
- [x] Querydsl 적용

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
- 관심 등록된 전시회 중 ON_DISPLAY인 전시회 && 별점/리뷰가 없는 전시회를 조회하는데 spring data jpa 쿼리메서드로는 힘들어서, `Querydsl`을 적용해서 해결했습니다.
- 기존의 `AlarmService`의 규모가 커져서, 알림을 조회하는 로직만 남겨두고 알림을 생성하는 로직들은 `AlarmCreateService`를 만들어 옮겼습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->


## 주의사항
<!-- 이슈를 닫기 위한 이슈 번호를 적어주세요! -->
Closes #104 
