### PR TITLE
✨ [FEAT]: Report 카운팅 기능 추가

### DIFF
--- a/src/main/java/depth/jeonsilog/domain/report/application/ReportService.java
+++ b/src/main/java/depth/jeonsilog/domain/report/application/ReportService.java
@@ -2,7 +2,8 @@ package depth.jeonsilog.domain.report.application;
 
 import depth.jeonsilog.domain.exhibition.application.ExhibitionService;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
-import depth.jeonsilog.domain.exhibition.domain.repository.ExhibitionRepository;
+import depth.jeonsilog.domain.place.application.PlaceService;
+import depth.jeonsilog.domain.place.domain.Place;
 import depth.jeonsilog.domain.reply.application.ReplyService;
 import depth.jeonsilog.domain.reply.domain.repository.ReplyRepository;
 import depth.jeonsilog.domain.report.converter.ReportConverter;
@@ -21,7 +22,6 @@ import depth.jeonsilog.global.config.security.token.UserPrincipal;
 import depth.jeonsilog.global.payload.ApiResponse;
 import depth.jeonsilog.global.payload.Message;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -41,12 +41,12 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final ReviewRepository reviewRepository;
     private final ReplyRepository replyRepository;
-    private final ExhibitionRepository exhibitionRepository;
 
     private final UserService userService;
     private final ReviewService reviewService;
     private final ReplyService replyService;
     private final ExhibitionService exhibitionService;
+    private final PlaceService placeService;
 
     // TODO Think : Report의 reportedId는 타입 별 해당 PK(ID)임 !
 
@@ -112,6 +112,18 @@ public class ReportService {
                 Exhibition exhibition = exhibitionService.validateExhibitionById(id);
                 DefaultAssert.isTrue(exhibition.getImageUrl() == null, "이미 등록된 포스터가 존재합니다.");
             }
+            case LINK -> {
+                Place place = placeService.validatePlaceById(id);
+                DefaultAssert.isTrue(place.getHomePage() == null, "이미 등록된 홈페이지 링크가 존재합니다.");
+            }
+            case ADDRESS -> {
+                Place place = placeService.validatePlaceById(id);
+                DefaultAssert.isTrue(place.getAddress() == null, "이미 등록된 주소가 존재합니다.");
+            }
+            case PHONE_NUMBER -> {
+                Place place = placeService.validatePlaceById(id);
+                DefaultAssert.isTrue(place.getTel() == null, "이미 등록된 전화번호가 존재합니다.");
+            }
         }
     }
 
@@ -125,6 +137,7 @@ public class ReportService {
                 case REVIEW -> target = reviewRepository.findReviewByReviewId(report.getReportedId());
                 case REPLY -> target = replyRepository.findReplyByReplyId(report.getReportedId());
                 case EXHIBITION -> target = exhibitionService.validateExhibitionById(report.getReportedId());
+                default -> target = placeService.validatePlaceById(report.getReportedId()); // LINK, ADDRESS, PHONE_NUMBER
             }
             targetList.add(target);
         }

--- a/src/main/java/depth/jeonsilog/domain/report/converter/ReportConverter.java
+++ b/src/main/java/depth/jeonsilog/domain/report/converter/ReportConverter.java
@@ -64,6 +64,7 @@ public class ReportConverter {
                     .reportedId(report.getReportedId())
                     .clickId(clickId)
                     .isChecked(report.getIsChecked())
+//                    .counting()
                     .build();
 
             reportResList.add(reportRes);

--- a/src/main/java/depth/jeonsilog/domain/report/converter/ReportConverter.java
+++ b/src/main/java/depth/jeonsilog/domain/report/converter/ReportConverter.java
@@ -3,7 +3,6 @@ package depth.jeonsilog.domain.report.converter;
 import depth.jeonsilog.domain.common.Status;
 import depth.jeonsilog.domain.exhibition.domain.Exhibition;
 import depth.jeonsilog.domain.reply.domain.Reply;
-import depth.jeonsilog.domain.reply.dto.ReplyResponseDto;
 import depth.jeonsilog.domain.report.domain.Report;
 import depth.jeonsilog.domain.report.domain.ReportType;
 import depth.jeonsilog.domain.report.dto.ReportResponseDto;
@@ -52,19 +51,18 @@ public class ReportConverter {
                 name = user.getNickname();
                 clickId = reply.getReview().getId();
 
-            } else if (target instanceof Exhibition) {
+            } else {
                 Exhibition exhibition = (Exhibition) target;
                 name = exhibition.getName();
                 clickId = exhibition.getId();
             }
             ReportResponseDto.ReportRes reportRes = ReportResponseDto.ReportRes.builder()
-                    .reportId(report.getId())
                     .name(name) // 신고된 유저 혹은 전시회 이름
                     .reportType(report.getReportType())
                     .reportedId(report.getReportedId())
                     .clickId(clickId)
                     .isChecked(report.getIsChecked())
-//                    .counting()
+                    .counting(report.getCounting())
                     .build();
 
             reportResList.add(reportRes);

--- a/src/main/java/depth/jeonsilog/domain/report/domain/Report.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/Report.java
@@ -41,5 +41,4 @@ public class Report extends BaseEntity {
         this.reportedId = reportedId;
         this.isChecked = isChecked;
     }
-
 }

--- a/src/main/java/depth/jeonsilog/domain/report/domain/Report.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/Report.java
@@ -29,8 +29,14 @@ public class Report extends BaseEntity {
 
     private Boolean isChecked = false;
 
+    private Integer counting;
+
     public void updateChecked (boolean isChecked) {
         this.isChecked = isChecked;
+    }
+
+    public void updateCounting(int counting) {
+        this.counting = counting;
     }
 
     @Builder
@@ -40,5 +46,6 @@ public class Report extends BaseEntity {
         this.reportType = reportType;
         this.reportedId = reportedId;
         this.isChecked = isChecked;
+        this.counting = 1;
     }
 }

--- a/src/main/java/depth/jeonsilog/domain/report/domain/ReportType.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/ReportType.java
@@ -1,5 +1,5 @@
 package depth.jeonsilog.domain.report.domain;
 
 public enum ReportType {
-    EXHIBITION, REVIEW, REPLY
+    EXHIBITION, REVIEW, REPLY, ADDRESS, PHONE_NUMBER, LINK
 }

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepository.java
@@ -1,0 +1,4 @@
+package depth.jeonsilog.domain.report.domain.repository;
+
+public interface ReportQuerydslRepository {
+}

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepository.java
@@ -1,4 +1,11 @@
 package depth.jeonsilog.domain.report.domain.repository;
 
+import depth.jeonsilog.domain.report.domain.Report;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
 public interface ReportQuerydslRepository {
+
+    Page<Report> findReportsWithSortingAndCounting(Pageable pageable);
 }

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepositoryImpl.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepositoryImpl.java
@@ -1,0 +1,4 @@
+package depth.jeonsilog.domain.report.domain.repository;
+
+public class ReportQuerydslRepositoryImpl implements ReportQuerydslRepository{
+}

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepositoryImpl.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportQuerydslRepositoryImpl.java
@@ -1,4 +1,56 @@
 package depth.jeonsilog.domain.report.domain.repository;
 
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import depth.jeonsilog.domain.exhibition.domain.QExhibition;
+import depth.jeonsilog.domain.reply.domain.QReply;
+import depth.jeonsilog.domain.report.domain.QReport;
+import depth.jeonsilog.domain.report.domain.Report;
+import depth.jeonsilog.domain.review.domain.QReview;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
 public class ReportQuerydslRepositoryImpl implements ReportQuerydslRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Report> findReportsWithSortingAndCounting(Pageable pageable) {
+        QReport report = QReport.report;
+        QReply reply = QReply.reply;
+        QReview review = QReview.review;
+        QExhibition exhibition = QExhibition.exhibition;
+
+        List<Report> content = queryFactory
+                .selectFrom(report)
+                .leftJoin(reply).on(reply.id.eq(report.reportedId))
+                .leftJoin(review).on(review.id.eq(reply.review.id))
+                .leftJoin(exhibition).on(exhibition.id.eq(report.reportedId))
+                .where(report.id.in(
+                        JPAExpressions.select(report.id.min())
+                                .from(report)
+                                .groupBy(report.reportType, report.reportedId, report.isChecked)
+                ))
+                .orderBy(report.isChecked.asc(), report.createdDate.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .selectFrom(report)
+                .where(report.id.in(
+                        JPAExpressions.select(report.id.min())
+                                .from(report)
+                                .groupBy(report.reportType, report.reportedId, report.isChecked)
+                ))
+                .fetch()
+                .size();
+
+        return new PageImpl<>(content, pageable, total);
+    }
 }

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ReportRepository extends JpaRepository<Report, Long> {
+public interface ReportRepository extends JpaRepository<Report, Long>, ReportQuerydslRepository {
 
     Page<Report> findAll(Pageable pageable);
 

--- a/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportRepository.java
+++ b/src/main/java/depth/jeonsilog/domain/report/domain/repository/ReportRepository.java
@@ -1,11 +1,14 @@
 package depth.jeonsilog.domain.report.domain.repository;
 
 import depth.jeonsilog.domain.report.domain.Report;
+import depth.jeonsilog.domain.report.domain.ReportType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long>, ReportQuerydslRepository {
@@ -13,4 +16,6 @@ public interface ReportRepository extends JpaRepository<Report, Long>, ReportQue
     Page<Report> findAll(Pageable pageable);
 
     Slice<Report> findSliceBy(Pageable pageable);
+
+    List<Report> findByReportedIdAndReportType(Long reportedId, ReportType reportType);
 }

--- a/src/main/java/depth/jeonsilog/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/depth/jeonsilog/domain/report/dto/ReportRequestDto.java
@@ -9,10 +9,10 @@ public class ReportRequestDto {
     @Data
     public static class ReportReq {
 
-        @Schema(type = "ReportType", example = "REVIEW", description = "신고 타입입니다. EXHIBITION, REVIEW, REPLY 中 1")
+        @Schema(type = "ReportType", example = "REVIEW", description = "신고 타입입니다. EXHIBITION, REVIEW, REPLY, LINK, ADDRESS, PHONE_NUMBER 中 1")
         private ReportType reportType;
 
-        @Schema(type = "Long", example = "1", description = "신고된 감상평, 댓글 혹은 전시회의 id입니다.")
+        @Schema(type = "Long", example = "1", description = "신고된 감상평, 댓글, 전시회, 전시공간의 ID 입니다.")
         private Long reportedId;
 
     }

--- a/src/main/java/depth/jeonsilog/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/depth/jeonsilog/domain/report/dto/ReportResponseDto.java
@@ -31,6 +31,9 @@ public class ReportResponseDto {
 
         @Schema(type = "boolean", example = "true", description = "신고를 확인했는지 출력합니다.")
         private Boolean isChecked;
+
+        @Schema(type = "Integer", example = "7", description = "알림 카운팅입니다.")
+        private Integer counting;
     }
 
     @Data

--- a/src/main/java/depth/jeonsilog/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/depth/jeonsilog/domain/report/dto/ReportResponseDto.java
@@ -1,10 +1,10 @@
 package depth.jeonsilog.domain.report.dto;
 
-import depth.jeonsilog.domain.reply.dto.ReplyResponseDto;
 import depth.jeonsilog.domain.report.domain.ReportType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -14,9 +14,7 @@ public class ReportResponseDto {
     @Builder
     public static class ReportRes {
 
-        @Schema(type = "Long", example = "1", description = "신고 ID를 출력합니다.")
-        private Long reportId;
-
+        @Setter
         @Schema(type = "String", example = "1", description = "신고된 감상평/댓글 작성자 혹은 전시회 이름이 출력합니다.")
         private String name;
 
@@ -32,8 +30,17 @@ public class ReportResponseDto {
         @Schema(type = "boolean", example = "true", description = "신고를 확인했는지 출력합니다.")
         private Boolean isChecked;
 
-        @Schema(type = "Integer", example = "7", description = "알림 카운팅입니다.")
+        @Schema(type = "Long", example = "7", description = "알림 카운팅입니다.")
         private Integer counting;
+
+        public ReportRes(final String name, final ReportType reportType, final Long reportedId, final Long clickId, final Boolean isChecked, final Integer counting) {
+            this.name = name;
+            this.reportType = reportType;
+            this.reportedId = reportedId;
+            this.clickId = clickId;
+            this.isChecked = isChecked;
+            this.counting = counting;
+        }
     }
 
     @Data

--- a/src/main/java/depth/jeonsilog/domain/report/presentation/ReportController.java
+++ b/src/main/java/depth/jeonsilog/domain/report/presentation/ReportController.java
@@ -61,12 +61,11 @@ public class ReportController {
             @ApiResponse(responseCode = "200", description = "확인 성공", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
             @ApiResponse(responseCode = "400", description = "확인 실패", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))}),
     })
-    @PatchMapping("/check/{reportId}")
+    @PatchMapping("/check")
     public ResponseEntity<?> checkReport(
             @Parameter(description = "Access Token을 입력해주세요.", required = true) @CurrentUser UserPrincipal userPrincipal,
-            @Parameter(description = "신고 Id를 입력해주세요.", required = true) @PathVariable(value = "reportId") Long reportId
+            @Parameter(description = "Schemas의 ReportReq를 참고해주세요", required = true) @RequestBody ReportRequestDto.ReportReq reportReq
     ) {
-        return reportService.checkReport(userPrincipal, reportId);
+        return reportService.checkReport(userPrincipal, reportReq);
     }
-
 }

--- a/src/main/java/depth/jeonsilog/domain/stop/application/StopService.java
+++ b/src/main/java/depth/jeonsilog/domain/stop/application/StopService.java
@@ -5,6 +5,7 @@ import depth.jeonsilog.domain.stop.domain.repository.StopRepository;
 import depth.jeonsilog.domain.stop.dto.StopRequestDto;
 import depth.jeonsilog.domain.stop.dto.StopResponseDto;
 import depth.jeonsilog.domain.user.application.UserService;
+import depth.jeonsilog.domain.user.domain.Role;
 import depth.jeonsilog.domain.user.domain.User;
 import depth.jeonsilog.domain.user.domain.repository.UserRepository;
 import depth.jeonsilog.global.DefaultAssert;
@@ -36,7 +37,7 @@ public class StopService {
     @Transactional
     public ResponseEntity<?> stopUser(final UserPrincipal userPrincipal, final StopRequestDto.StopUserReq dto) {
         User admin = userService.validateUserByToken(userPrincipal);
-//        DefaultAssert.isTrue(admin.getRole().equals(Role.ADMIN), "관리자만 유저를 정지할 수 있습니다.");
+        DefaultAssert.isTrue(admin.getRole().equals(Role.ADMIN), "관리자만 유저를 정지할 수 있습니다.");
 
         Optional<User> targetUser = userRepository.findById(dto.getUserId());
         DefaultAssert.isTrue(targetUser.isPresent(), "정지시키려는 유저가 올바르지 않습니다.");


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[FEAT]: PR을 등록한다.`
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] Report 엔티티 - ReportType Enum 타입 추가: ADDRESS, LINK, PHONE_NUMBER
- [x] Report 엔티티 - counting 컬럼 추가
- [x] ReportService - 신고 조회 메서드에서 reportedId + reportType 으로 그룹핑해서 조회
- [x] ReportService - 신고 생성 메서드에서 isChecked와 counting 값 업데이트
- [x] ReportService - 신고 확인 메서드에서 같은 내용의 신고들에 대해 모두 isChecked 업데이트

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
매우 고된 작업이었습니다.. 이렇게 오래 걸릴 줄 몰랐고.. 
카운팅 기능을 구현하기 위해 두 가지 방법을 고려했습니다.

> 1. 엔티티에 카운팅 컬럼을 추가하고 같은 내용의 신고가 추가된 경우 저장하지 않고 카운팅만 +1한다. 
> 2. 카운팅 컬럼 없이 같은 내용이여도 모두 DB에 저장한다. 

1번은 데이터를 생성할 때 DB 조회하는 작업이 일어나고 조회할 때 매우 간단합니다. 2번은 생성할 때 간단하지만 조회가 매우 복잡해집니다.
그래서 1번으로 진행하려 했으나, Report에는 User가 다대일로 매핑되어있고 1번으로 개발할 시, 같은 내용의 두 번째 신고부터는 User 정보를 받을 수 없게됩니다. 물론 프로젝트 규모상 크게 상관없을 수도 있으나 저는 이 부분이 매우 거슬렸고,, 2번으로 눈을 돌리게됩니다. 
조회할 때 `reportedId + reportType`으로 그룹핑을 하고, SQL 집계함수를 사용해서 counting값을 구합니다. 여러 데이터 중 하나를 대표해서 뽑는 것이다보니 reportId도 선정해야하고, 무엇보다 아래 SQL 문법이 매우 까다로웠습니다.

> SQL에서 집계 함수 (예: COUNT(), MIN(), MAX() 등)를 사용하면, SELECT 문에 명시된 집계 함수가 아닌 다른 모든 컬럼은 GROUP BY 절에 포함되어야 합니다.

몇 시간 동안 삽질을 진행하고, 1+2번을 섞어서 진행하기로 했습니다. 엔티티에 카운팅 컬럼도 넣고 모두 개별 저장도 진행합니다. 이 방법은 아래와 같은 장점이 있습니다.
- 데이터는 개별적으로 저장하여 무결성을 유지합니다.
- 조회 시에는 이 집계된 정보를 기반으로 빠르게 데이터를 제공할 수 있습니다.
***
ReportRes에 변경사항이 있습니다. reportId가 빠지고 counting이 추가되었습니다. 같은 내용의 신고가 그룹핑 되어 조회되기 때문에 reportId의 의미가 퇴색된다고 생각했고 따라서 신고 확인 메서드 DTO가 reportId에서 `reportedId + reportType`으로 변경되었습니다.

StopService에 주석 처리 해놓았던 부분도 해제했습니다.

## Reference 🔬 
<!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->


## 주의사항
<!-- 이슈를 닫기 위한 이슈 번호를 적어주세요! -->
Closes #108 
